### PR TITLE
3-3-5_task_delete

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,12 +12,19 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @task = Task.find(params[:id])
   end
 
   def create
     task = Task.new(task_params)
     task.save!
     redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+  end
+
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,6 +27,12 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
+  def destroy
+    task = Task.find(params[:id])
+    task.destroy
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+  end
+
   private
 
   def task_params

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task-description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,8 +1,8 @@
 = form_with model: task, local: true do |f|
-  .form-group
+  .mb-3
     = f.label :name
     = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
+  .mb-3
     = f.label :description
     = f.text_area :description, rows: 5, class: 'form-control', id: 'task-description'
   = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,2 +1,13 @@
-h1 Tasks#edit
-p Find me in app/views/tasks/edit.html.slim
+h1 タスクの編集
+
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,11 +3,4 @@ h1 タスクの編集
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -7,8 +7,11 @@ table.table.table-hover
     tr
       th= Task.human_attribute_name(:name)
       th= Task.human_attribute_name(:created_at)
+      th
   tbody
     - @tasks.each do |task|
       tr
         td= link_to task.name, task
         td= task.created_at
+        td
+          = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -15,3 +15,4 @@ table.table.table-hover
         td= task.created_at
         td
           = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'
+          = link_to '削除', task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -14,5 +14,5 @@ table.table.table-hover
         td= link_to task.name, task
         td= task.created_at
         td
-          = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'
+          = link_to '編集', edit_task_path(task), class: 'btn btn-primary me-3'
           = link_to '削除', task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,11 +3,4 @@ h1 タスクの新規登録
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task-description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -19,3 +19,5 @@ table.table.table-hover
     tr
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
+
+= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -21,3 +21,4 @@ table.table.table-hover
       td= @task.updated_at
 
 = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to '削除', @task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -20,5 +20,5 @@ table.table.table-hover
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
 
-= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to '編集', edit_task_path, class: 'btn btn-primary me-3'
 = link_to '削除', @task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'


### PR DESCRIPTION
「3-3-5 削除機能を実装する」まで完了しましたのでご確認お願いいたします。
# 3-3-4 編集機能を実装する
- 一覧画面に編集ボタンが表示される
<img width="1470" alt="スクリーンショット 2025-05-09 13 04 56" src="https://github.com/user-attachments/assets/ed4ba516-eedd-41f7-9700-45e7f7787480" />

- 詳細画面に編集ボタンが表示される
<img width="1470" alt="スクリーンショット 2025-05-09 13 05 07" src="https://github.com/user-attachments/assets/5e4fd9db-087d-4687-af23-5492c79ac285" />

- 編集画面が正しく表示される
<img width="1470" alt="スクリーンショット 2025-05-09 13 17 30" src="https://github.com/user-attachments/assets/d2541186-3456-4a51-8f37-63ba5bca2776" />

- 編集が正しく実行できる
<img width="1470" alt="スクリーンショット 2025-05-09 13 18 51" src="https://github.com/user-attachments/assets/2fa5f412-8f15-42f9-9ebf-b75a72c09cc6" />


# 3-3-4-1 パーシャルを使った新規登録画面と編集画面の共通化
- 入力フォームの共通化後も新規登録画面の表示が変わらない
<img width="1470" alt="スクリーンショット 2025-05-09 13 22 59" src="https://github.com/user-attachments/assets/fc069959-ddfb-4cc6-9d1d-151d51a1aafb" />

- 入力フォームの共通化後も編集画面の表示が変わらない
<img width="1470" alt="スクリーンショット 2025-05-09 13 23 10" src="https://github.com/user-attachments/assets/d440266d-a800-49b9-8758-6e167032a9e6" />


# 3-3-5 削除機能を実装する
[Q: data-methodが動かない](https://github.com/luxiar/onboarding/wiki/%E7%A0%94%E4%BF%AE%E4%B8%AD%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0)

- 一覧画面に削除ボタンが表示される
- 削除ボタン押下で確認ダイアログが表示される
<img width="1470" alt="スクリーンショット 2025-05-09 13 46 36" src="https://github.com/user-attachments/assets/59d54da6-e92a-43f2-80f2-8d682eb8a42f" />

- 詳細画面に削除ボタンが表示される
- 削除ボタン押下で確認ダイアログが表示される
<img width="1470" alt="スクリーンショット 2025-05-09 13 47 24" src="https://github.com/user-attachments/assets/32c0cc12-99bc-4c06-8f17-acd5d253e913" />

- 削除が正しく実行できる
- Flashメッセージが表示される
<img width="1470" alt="スクリーンショット 2025-05-09 13 50 36" src="https://github.com/user-attachments/assets/9e2da245-5726-4f30-901f-2755c2bbd1bb" />
