### PR TITLE
4-5_login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bindex (0.8.1)
@@ -343,6 +344,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   bootstrap
   brakeman

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,4 +46,8 @@ class Admin::UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
   end
+
+  def require_admin
+    redirect_to root_url unless current_user.admin?
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :require_admin
-  before_action :find_user, only: [:show, :edit, :update, :destroy]
+  before_action :find_user, only: [ :show, :edit, :update, :destroy ]
 
   def index
     @users = User.all

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,49 @@
+class Admin::UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @user = User.find(params[:id])
+
+    if @user.update(user_params)
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to admin_users_url, notice: "ユーザー「#{@user.name}」を削除しました。"
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,12 +1,12 @@
 class Admin::UsersController < ApplicationController
   before_action :require_admin
+  before_action :find_user, only: [:show, :edit, :update, :destroy]
 
   def index
     @users = User.all
   end
 
   def show
-    @user = User.find(params[:id])
   end
 
   def new
@@ -14,7 +14,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def edit
-    @user = User.find(params[:id])
   end
 
   def create
@@ -28,8 +27,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def update
-    @user = User.find(params[:id])
-
     if @user.update(user_params)
       redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
     else
@@ -38,7 +35,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
-    @user = User.find(params[:id])
     @user.destroy
     redirect_to admin_users_url, notice: "ユーザー「#{@user.name}」を削除しました。"
   end
@@ -51,5 +47,9 @@ class Admin::UsersController < ApplicationController
 
   def require_admin
     redirect_to root_url unless current_user.admin?
+  end
+
+  def find_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < ApplicationController
+  before_action :require_admin
+
   def index
     @users = User.all
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,14 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user
+  before_action :login_required
 
   private
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def login_required
+    redirect_to login_url unless current_user
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  helper_method :current_user
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :login_required
+
   def new
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+class SessionsController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,6 +13,11 @@ class SessionsController < ApplicationController
     end
   end
 
+  def destroy
+    reset_session
+    redirect_to root_url, notice: "ログアウトしました。"
+  end
+
   private
 
   def session_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,21 @@
 class SessionsController < ApplicationController
   def new
   end
+
+  def create
+    user = User.find_by(email: session_params[:email])
+
+    if user&.authenticate(session_params[:password])
+      session[:user_id] = user.id
+      redirect_to root_url, notice: "ログインしました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,10 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = current_user.tasks
   end
 
   def show
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def new
@@ -12,7 +12,7 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def create
@@ -26,13 +26,13 @@ class TasksController < ApplicationController
   end
 
   def update
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.update!(task_params)
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   def destroy
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.destroy
     redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,11 @@
 class TasksController < ApplicationController
+  before_action :find_task, only: [:show, :edit, :update, :destroy]
+
   def index
     @tasks = current_user.tasks
   end
 
   def show
-    @task = current_user.tasks.find(params[:id])
   end
 
   def new
@@ -12,7 +13,6 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = current_user.tasks.find(params[:id])
   end
 
   def create
@@ -26,20 +26,22 @@ class TasksController < ApplicationController
   end
 
   def update
-    task = current_user.tasks.find(params[:id])
-    task.update!(task_params)
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
+    @task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{@task.name}」を更新しました。"
   end
 
   def destroy
-    task = current_user.tasks.find(params[:id])
-    task.destroy
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+    @task.destroy
+    redirect_to tasks_url, notice: "タスク「#{@task.name}」を削除しました。"
   end
 
   private
 
   def task_params
     params.require(:task).permit(:name, :description)
+  end
+
+  def find_task
+    @task = current_user.tasks.find(params[:id])
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,7 +16,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.new(task_params)
 
     if @task.save
       redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :find_task, only: [:show, :edit, :update, :destroy]
+  before_action :find_task, only: [ :show, :edit, :update, :destroy ]
 
   def index
     @tasks = current_user.tasks

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,8 @@ class Task < ApplicationRecord
   validates :name, length: { maximum: 30 }
   validate :validate_name_not_including_comma
 
+  belongs_to :user
+
   private
 
   def validate_name_not_including_comma

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
+
+  has_many :tasks
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_secure_password
 end

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,0 +1,23 @@
+- if user.errors.present?
+  ul#error_explanation
+    - user.errors.full_messages.each do |message|
+      li= message
+
+= form_with model: [:admin, user], local: true do |f|
+  .mb-3
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者権限
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .mb-3
+    = f.label :password_confirmation, 'パスワード(確認)'
+    = f.password_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,6 @@
+h1 ユーザーの編集
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,25 @@
+h1 ユーザー一覧
+
+= link_to '新規登録', new_admin_user_path, class: 'btn btn-primary'
+
+.mb-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= User.human_attribute_name(:name)
+      th= User.human_attribute_name(:email)
+      th= User.human_attribute_name(:admin)
+      th= User.human_attribute_name(:created_at)
+      th= User.human_attribute_name(:updated_at)
+      th
+  tbody
+    - @users.each do |user|
+      tr
+        td= link_to user.name, [:admin, user]
+        td= user.email
+        td= user.admin? ? 'あり' : 'なし'
+        td= user.created_at
+        td= user.updated_at
+        td
+          = link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary me-3'
+          = link_to '削除', [:admin, user], data: { turbo_method: :delete, turbo_confirm: "ユーザー「#{user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,0 +1,6 @@
+h1 ユーザー登録
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,0 +1,27 @@
+h1 ユーザーの詳細
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+table.table.table-hover
+  tbody
+    tr
+      th= User.human_attribute_name(:id)
+      td= @user.id
+    tr
+      th= User.human_attribute_name(:name)
+      td= @user.name
+    tr
+      th= User.human_attribute_name(:email)
+      td= @user.email
+    tr
+      th= User.human_attribute_name(:admin)
+      td= @user.admin? ? 'あり' : 'なし'
+    tr
+      th= User.human_attribute_name(:created_at)
+      td= @user.created_at
+    tr
+      th= User.human_attribute_name(:updated_at)
+      td= @user.updated_at
+
+= link_to '編集', edit_admin_user_path, class: 'btn btn-primary me-3'
+= link_to '削除', [:admin, @user], data: { turbo_method: :delete, turbo_confirm: "ユーザー「#{@user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -21,7 +21,8 @@ html
       ul.navbar-nav.ml-auto
         - if current_user
           li.nav-item= link_to 'タスク一覧', tasks_path, class: 'nav-link'
-          li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          - if current_user.admin?
+            li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
           li.nav-item= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'nav-link'
         - else
           li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,6 +17,14 @@ html
   body
     .app-title.navbar.navbar-expand-md.navbar-light.bg-light
       .navbar-brand Taskleaf
+
+      ul.navbar-nav.ml-auto
+        - if current_user
+          li.nav-item= link_to 'タスク一覧', tasks_path, class: 'nav-link'
+          li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          li.nav-item= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'nav-link'
+        - else
+          li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'
     .container
       - if flash.notice.present?
         .alert.alert-success= flash.notice

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,0 +1,10 @@
+h1 ログイン
+
+= form_with scope: :session, local: true do |f|
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control', id: 'session_email'
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control', id: 'session-password'
+  = f.submit 'ログインする', class: 'btn btn-primary'

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,7 +1,7 @@
 - if task.errors.present?
   ul#error_explosion
     - task.errors.full_messages.each do |message|
-      li = message
+      li= message
 
 = form_with model: task, local: true do |f|
   .mb-3

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,7 +1,7 @@
 h1 タスク一覧
 = link_to '新規登録', new_task_path, class: 'btn btn-primary'
 
-.mb_3
+.mb-3
 table.table.table-hover
   thead.thead-default
     tr

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,28 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "eb5faf44a3c065b7fc702828e2e055450a32c5681841a621895ca0400c7d85ce",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/admin/users_controller.rb",
+      "line": 49,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::UsersController",
+        "method": "user_params"
+      },
+      "user_input": ":admin",
+      "confidence": "High",
+      "cwe_id": [
+        915
+      ],
+      "note": "BrakemanのMass Assignment警告回避のため無視設定。学習目的のため一時的に許可。"
+    }
+  ],
+  "brakeman_version": "7.0.2"
+}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,15 @@ ja:
         description: 詳しい説明
         created_at: 登録日時
         updated_at: 更新日時
+      user:
+        id: ID
+        name: 名前
+        email: メールアドレス
+        admin: 管理者権限
+        password: パスワード
+        password_confirmation: パスワード(確認)
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "/login", to: "sessions#new"
+
   namespace :admin do
     resources :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
+
   root to: "tasks#index"
   resources :tasks
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "/login", to: "sessions#new"
+  post "/login", to: "sessions#create"
 
   namespace :admin do
     resources :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
+  delete "/logout", to: "sessions#destroy"
 
   namespace :admin do
     resources :users

--- a/db/migrate/20250512041116_create_users.rb
+++ b/db/migrate/20250512041116_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+      t.index :email, unique: true
+    end
+  end
+end

--- a/db/migrate/20250512044423_add_admin_to_users.rb
+++ b/db/migrate/20250512044423_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20250512083003_add_user_id_to_tasks.rb
+++ b/db/migrate/20250512083003_add_user_id_to_tasks.rb
@@ -1,0 +1,10 @@
+class AddUserIdToTasks < ActiveRecord::Migration[7.2]
+  def up
+    execute 'DELETE FROM tasks;'
+    add_reference :tasks, :user, null: false, index: true
+  end
+
+  def down
+    remove_reference :tasks, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_12_012001) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_041116) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,5 +19,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_12_012001) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_12_041116) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_044423) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_12_041116) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_12_044423) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_083003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_12_044423) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
「4-5 ログイン機能を作る」が完了しましたのでご確認お願いいたします。
~~CIでPotentially dangerous key allowed for mass assignmentの警告が出ています。~~ 警告無視設定を追加しました

# 4-5-2 Userモデルを作る
Userモデルのオブジェクトが作成できる
<img width="963" alt="スクリーンショット 2025-05-12 13 19 13" src="https://github.com/user-attachments/assets/525a1a6f-865d-41d7-9e45-53d7c74127bf" />

# 4-5-3 パスワードを受け付けてdigestを保存する
パスワードの入力を受け付けてdigestを生成・保存している
<img width="953" alt="スクリーンショット 2025-05-12 13 37 03" src="https://github.com/user-attachments/assets/94e08ebd-fcb7-42db-8f17-19afcfef9e46" />

# 4-5-4-1 Userモデルにadminフラグを追加する
# 4-5-4-2 ユーザー管理のためのコントローラを実装する
ユーザー登録画面が表示できる
管理者権限(admin)の項目がある
<img width="1470" alt="スクリーンショット 2025-05-12 14 13 11" src="https://github.com/user-attachments/assets/6f938aac-2a52-421b-bf3c-e48bdefe083d" />

エラーメッセージが表示される
名前・メールアドレス・パスワードが空欄でエラーになる
![スクリーンショット 2025-05-12 16 11 56](https://github.com/user-attachments/assets/bfe42c4c-5699-4a6d-9c8b-a4fa0ced642f)

ユーザー編集画面が表示できる
エラー時に入力内容が残る
メールアドレスの重複でエラーになる
パスワードが一致しないとエラーになる
![スクリーンショット 2025-05-12 16 13 54](https://github.com/user-attachments/assets/1b21f549-71c5-4cd5-83a4-b80dbe85276a)

ユーザー詳細画面が表示できる
項目名が日本語になっている
ユーザー登録ができる
通知が表示される
![スクリーンショット 2025-05-12 16 14 20](https://github.com/user-attachments/assets/af80fc2a-92f3-4f9c-a00a-23d9604b951c)

ユーザー一覧画面が表示できる
ユーザーの削除ができる
![スクリーンショット 2025-05-12 16 17 03](https://github.com/user-attachments/assets/a65dcc7f-d68a-41ce-8aa4-2538d6f9a6d8)

# 4-5-6 ログインのフォームを表示する
ログイン画面が表示できる
![スクリーンショット 2025-05-12 17 23 03](https://github.com/user-attachments/assets/00e5ec8c-5eed-416d-ac22-7ab535ee8699)

# 4-5-7 ログインの実行
ログインができる
![スクリーンショット 2025-05-12 16 51 32](https://github.com/user-attachments/assets/61a313ec-405d-4f3a-bcc8-a97f32385009)

# 4-5-8 ログイン情報の取得を簡単にする
# 4-5-9 ログアウト機能を実装する
ログイン中は左上に「タスク一覧」「ユーザー一覧」「ログアウト」リンクが表示される
![スクリーンショット 2025-05-12 17 16 25](https://github.com/user-attachments/assets/f0bcf45b-4f64-4ff0-8d0d-b2265a6d5169)

ログアウトができる
ログアウトすると左上のリンクが「ログイン」のみになっている
![スクリーンショット 2025-05-12 17 14 18](https://github.com/user-attachments/assets/357f0737-ae08-446e-ba5f-753d221b7589)

# 4-5-10 ログインしていなければタスク管理を利用できなくする
ログイン済みでない場合ログイン画面にリダイレクトする
![スクリーンショット 2025-05-12 17 23 03](https://github.com/user-attachments/assets/20f3a5da-a8a5-459d-862c-bd86374121fe)

# 4-5-11-1 データベース上でUserとTaskを紐付ける
# 4-5-11-2 Railsの「関連」を定義する
# 4-5-11-3 ログインしているユーザーのTaskデータの登録
# 4-5-11-4 ログインしているユーザーのTaskデータだけを読み出す
自身のタスクしか見えていない
![スクリーンショット 2025-05-12 17 57 03](https://github.com/user-attachments/assets/9754b4ef-a92e-4121-ad3e-217a29be5bc0)
![スクリーンショット 2025-05-12 17 58 11](https://github.com/user-attachments/assets/92b5e2b0-016d-4860-a64a-8e159eed0324)

他人のタスクのURLを打ち込むとエラーで見ることができない
<img width="1470" alt="スクリーンショット 2025-05-13 9 40 38" src="https://github.com/user-attachments/assets/ab541939-663b-4713-9d38-439816ce2b35" />
<img width="1470" alt="スクリーンショット 2025-05-13 9 41 04" src="https://github.com/user-attachments/assets/60d8faa1-a012-4a1b-9fe8-095c8ae8115a" />

# 4-5-12 管理機能を管理者ユーザーだけに利用させるようにする
管理者ユーザーには左上に「ユーザー一覧」が表示され、ユーザー管理機能が使用できる
![image](https://github.com/user-attachments/assets/e1067813-0517-4253-b04c-5383b72b7fc1)

管理者ユーザー以外には左上に「ユーザー一覧」が表示されず、管理機能のURLを打ち込んでもTOP画面にリダイレクトする
<img width="1470" alt="スクリーンショット 2025-05-13 9 52 51" src="https://github.com/user-attachments/assets/17f422ff-3bf4-4dcb-97ac-8639d13986ad" />
